### PR TITLE
Implement support for named tuples in partials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,15 @@ version = "0.1.0"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Suppressor"]

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -7,32 +7,62 @@
 # Note: Each partial derivative will have a different concrete type because
 # they are expected to be Quantities. 
 # N reflects the length of the tuple
-struct UnitPartials{N, TT <: Tuple}
+struct UnitPartials{N, TT <: Union{Tuple, NamedTuple}}
     partials::TT
 end
 
-# Constructors
-UnitPartials(t::Tuple) = UnitPartials{length(t), typeof(t)}(t)
-UnitPartials(args...) = UnitPartials(args)
+# Check if the an UnitPartials type contains a named tuple
+isnamed(::Type{UnitPartials{N,TT}}) where {N,TT} = length(TT.parameters) > 0 && TT.parameters[1] isa Tuple
 
-# Pretty printing
-function show(io::IO, up::UnitPartials)
-    print(io, '{', join(up.partials, ", "), '}')
+# Constructors
+UnitPartials(t::T) where T <: Union{Tuple, NamedTuple} = UnitPartials{length(t), typeof(t)}(t)
+UnitPartials(args...) = UnitPartials(args)
+UnitPartials(;kwargs...) = UnitPartials(values(kwargs))
+
+# Pretty printing -> includes names for named tuples
+function show(io::IO, up::T) where {T <: UnitPartials}
+    if isnamed(T)
+        names = keys(up.partials)
+        vals = values(up.partials)
+        pairs = string.(names) .* " = " .* string.(vals)
+        print(io, '{', join(pairs, ", "), '}')
+    else
+        print(io, '{', join(up.partials, ", "), '}')
+    end
 end
 
-# Forwarding methods to the underlying tuple
-function getindex(up::UnitPartials, i)
+# Forwarding getter methods to the underlying tuple
+function getindex(up::UnitPartials, i::Integer)
     @boundscheck i > length(up.partials) && throw(BoundsError(up, i))
     up.partials[i]
 end
+function getindex(up::T, n::Symbol) where {T <: UnitPartials}
+    !isnamed(T) && throw(DomainError(n, "Attempt to access named partial from an UnitPartials object that does not have named partials"))
+    getproperty(up.partials, n)
+end
+function getproperty(up::T, n::Symbol) where {T <: UnitPartials}
+    if n == :partials
+        getfield(up, :partials)
+    else
+        !isnamed(T) && throw(DomainError(up, "Attempt to access named partial from an UnitPartials object that does not have named partials"))
+        getfield(up.partials, n)
+    end
+end
+
 # Iterator interface
 length(up::UnitPartials) = length(up.partials)
 iterate(up::UnitPartials) = iterate(up.partials)
 iterate(up::UnitPartials, state) = iterate(up.partials, state)
 
-# Convenience functions
-zero(up::UnitPartials) = UnitPartials((zero(p) for p in up.partials)...)
+# Zero UnitPartials (by type or instance)
+zero(up::T) where {T <: UnitPartials} = zero(T)
+
 zero(::Type{UnitPartials{N,TT}}) where {N,TT <: Tuple} = UnitPartials((zero(p) for p in TT.parameters)...)
+
+function zero(::Type{UnitPartials{N,TT}}) where {N,TT <: NamedTuple}
+    z = Tuple((zero(p) for p in TT.parameters[2].parameters))
+    UnitPartials(namedtuple(TT.parameters[1], z))
+end
 
 ####################################################################################
 ################################# UnitDual #########################################
@@ -47,17 +77,15 @@ end
 # Constructors
 UnitDual(val, partials::Tuple) = UnitDual(val, UnitPartials(partials))
 UnitDual(val, args...) = UnitDual(val, UnitPartials(args)) 
+UnitDual(val; kwargs...) = UnitDual(val, UnitPartials(; kwargs...)) 
 
 # Setters and getters
 value(x::UnitDual) = x.value
 partials(x::UnitDual) = x.partials
 
 # Convenience functions
-zero(x::UnitDual) = UnitDual(zero(value(x)), zero(partials(x)))
+zero(x::T) where {T <: UnitDual} = zero(T)
 zero(::Type{UnitDual{DT, PT}}) where {DT, PT} = UnitDual(zero(DT), zero(PT))
-function zeros(x::T, n) where {T <:UnitDual}
-    T[zero(x) for i in 1:n]
-end
 
 # Pretty printing
 function show(io::IO, x::UnitDual)

--- a/src/UnitPartialsFunctions.jl
+++ b/src/UnitPartialsFunctions.jl
@@ -3,6 +3,45 @@
 # It is basically unrolling a loop over all partial derivatives
 # and performing the basic operations that required
 
+
+# Switch to the right generated function depending on type
+function add_partials(a::T1, b::T2)  where {T1, T2}
+    if isnamed(T1)
+        add_named_partials(a,b)
+    else
+        add_unnamed_partials(a,b)
+    end
+end
+function sub_partials(a::T1, b::T2)  where {T1, T2}
+    if isnamed(T1)
+        sub_named_partials(a,b)
+    else
+        sub_unnamed_partials(a,b)
+    end
+end
+function neg_partials(a::T1)  where T1
+    if isnamed(T1)
+        neg_named_partials(a)
+    else
+        neg_unnamed_partials(a)
+    end
+end
+function mul_partials(a::T1, b::T2, afactor, bfactor) where {T1, T2}
+    if isnamed(T1)
+        mul_named_partials(a,b, afactor, bfactor)
+    else
+        mul_unnamed_partials(a,b, afactor, bfactor)
+    end
+end
+function scale_partials(a::T1, x)  where T1
+    if isnamed(T1)
+        scale_named_partials(a, x)
+    else
+        scale_unnamed_partials(a, x)
+    end
+end
+
+# Operations on partial derivatives that are not named
 function partialexpr(f, N)
     ex = Expr(:tuple, [f(i) for i=1:N]...)
     return quote
@@ -11,19 +50,44 @@ function partialexpr(f, N)
     end
 end
 
-
-@generated function add_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1, T2}
+@generated function add_unnamed_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1 <: Tuple, T2 <: Tuple}
     return partialexpr(i -> :(a.partials[$i] + b.partials[$i]), N)
 end
-@generated function sub_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1, T2}
+@generated function sub_unnamed_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1 <: Tuple, T2 <: Tuple}
     return partialexpr(i -> :(a.partials[$i] - b.partials[$i]), N)
 end
-@generated function neg_partials(a::UnitPartials{N,T1})  where {N, T1, T2}
+@generated function neg_unnamed_partials(a::UnitPartials{N,T1})  where {N, T1 <: Tuple, T2 <: Tuple}
     return partialexpr(i -> :(-a.partials[$i]), N)
 end
-@generated function mul_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2}, afactor, bfactor)  where {N, T1, T2}
+@generated function mul_unnamed_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2}, afactor, bfactor)  where {N, T1 <: Tuple, T2 <: Tuple}
     return partialexpr(i -> :( (afactor*a.partials[$i]) + (bfactor*b.partials[$i])), N)
 end
-@generated function scale_partials(a::UnitPartials{N,T1}, x)  where {N, T1, T2}
+@generated function scale_unnamed_partials(a::UnitPartials{N,T1}, x)  where {N, T1 <: Tuple, T2 <: Tuple}
     return partialexpr(i -> :( x*a.partials[$i] ), N)
+end
+
+
+# Operations on partial derivatives that are named
+function namedpartialexpr(f, ::Val{names}) where names
+    ex = :(UnitPartials(;$((f(i) for i in names)...)))
+    return quote
+        $(Expr(:meta, :inline))
+        @inbounds return $ex
+    end
+end
+
+@generated function add_named_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1 <: NamedTuple, T2 <: NamedTuple}
+    return namedpartialexpr(i -> :($i = a.partials.$i + b.partials.$i), Val(T1.parameters[1]))
+end
+@generated function sub_named_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2})  where {N, T1 <: NamedTuple, T2 <: NamedTuple}
+    return namedpartialexpr(i -> :($i = a.partials.$i - b.partials.$i), Val(T1.parameters[1]))
+end
+@generated function neg_named_partials(a::UnitPartials{N,T1})  where {N, T1 <: NamedTuple, T2 <: NamedTuple}
+    return namedpartialexpr(i -> :($i = -a.partials.$i), Val(T1.parameters[1]))
+end
+@generated function mul_named_partials(a::UnitPartials{N,T1}, b::UnitPartials{N,T2}, afactor, bfactor)  where {N, T1 <: NamedTuple, T2 <: NamedTuple}
+    return namedpartialexpr(i -> :($i = (afactor*a.partials.$i) + (bfactor*b.partials.$i)), Val(T1.parameters[1]))
+end
+@generated function scale_named_partials(a::UnitPartials{N,T1}, x)  where {N, T1 <: NamedTuple, T2 <: NamedTuple}
+    return namedpartialexpr(i -> :($i = x*a.partials.$i), Val(T1.parameters[1]))
 end

--- a/src/UnitfulDual.jl
+++ b/src/UnitfulDual.jl
@@ -1,7 +1,8 @@
 module UnitfulDual
 
 import DiffRules
-import Base: show, inv, getindex, length, iterate, zero, zeros,
+using NamedTupleTools
+import Base: show, inv, getindex, getproperty, length, iterate, zero, zeros,
        +, *, -, /, ^, ==, isequal, isless, inv, isapprox,
        sqrt, cbrt, abs, abs2, log, log10, log2, exp, 
        sin, cos, tan, sec, csc, cot, acos, atan, asec, acsc, acot

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Suppressor
 
 @testset "UnitfulDual.jl" begin
 
-    # Creation of UnitDual numbers with tuple and args
+    # Creation of UnitDual numbers with tuple and args - unnamed
     a = 1.0u"mol/L"
     da = UnitDual(a, 1.0)
     da2 = UnitDual(a, (1.0, ))
@@ -14,7 +14,13 @@ using Suppressor
     @test value(da) === a
     @test partials(da) === UnitPartials((1.0))
 
-    # Dual numbers with several partials
+    # Creation of UnitDual numbers with tuple and args - named
+    nda = UnitDual(a, a = 1.0)
+    @test nda isa UnitDual
+    @test value(nda) === a
+    @test partials(nda) === UnitPartials((a = 1.0,))
+
+    # Dual numbers with several partials - unnamed
     a = 1.0u"mol/L"
     b = 0.5u"mol/L"
     c = 1.0u"1/s"
@@ -27,7 +33,17 @@ using Suppressor
 
     du = UnitDual(1.0, 1.0)
 
-    # Addition of Dual Numbers
+    # Dual numbers with several partials - named
+    nda = UnitDual(a, a = 1.0, b = 0.0, c = zero(a/c))
+    ndb = UnitDual(b, a = 0.0, b = 1.0, c = zero(b/c))
+    ndc = UnitDual(c, a = zero(c/a), b = zero(c/b), c = 1.0)
+    @test length(partials(nda)) == 3
+    @test partials(nda)[1] == 1.0
+    @test partials(nda)[3] isa Quantity
+
+    ndu = UnitDual(1.0, u = 1.0)
+
+    # Addition of Dual Numbers - unnamed
     dd = da + db
     @test dd isa UnitDual
     @test length(partials(dd)) == 3
@@ -40,8 +56,20 @@ using Suppressor
     @test partials(ddu) === UnitPartials(1.0)
     @test du + 1.0 === 1.0 + du
 
+    # Addition of Dual Numbers - named
+    ndd = nda + ndb
+    @test ndd isa UnitDual
+    @test length(partials(ndd)) == 3
+    @test value(ndd) == a + b
+    @test partials(ndd) === UnitPartials(a = 1.0, b = 1.0, c = zero(a/c))
+    @test_throws Unitful.DimensionError nda + ndc
+    @test_throws Unitful.DimensionError nda + 1
+    nddu = ndu + 1.0
+    @test value(nddu) == 2.0
+    @test partials(nddu) === UnitPartials(u = 1.0)
+    @test ndu + 1.0 === 1.0 + ndu
 
-    # Substraction of Dual Numbers
+    # Substraction of Dual Numbers - unnamed
     dd = da - db
     @test dd isa UnitDual
     @test length(partials(dd)) == 3
@@ -56,14 +84,38 @@ using Suppressor
     @test value(ddu) == 0.0
     @test partials(ddu) === UnitPartials(-1.0)
 
-    # Negation of Dual Numbers
+    # Substraction of Dual Numbers - named
+    ndd = nda - ndb
+    @test ndd isa UnitDual
+    @test length(partials(ndd)) == 3
+    @test value(ndd) == a - b
+    @test partials(ndd) === UnitPartials(a = 1.0, b = -1.0, c = zero(a/c))
+    @test_throws Unitful.DimensionError nda - ndc
+    @test_throws Unitful.DimensionError nda - 1
+    nddu = ndu - 1.0
+    @test value(nddu) == 0.0
+    @test partials(nddu) === UnitPartials(u = 1.0)
+    nddu = 1.0 - ndu
+    @test value(nddu) == 0.0
+    @test partials(nddu) === UnitPartials(u = -1.0)
+
+    # Negation of Dual Numbers - unnamed
     dd = -da
     @test dd isa UnitDual
     @test length(partials(dd)) == 3
     @test value(dd) == -a
     @test partials(dd) === UnitPartials((-t for t in partials(da))...)
 
-    # Multiplication of Dual Numbers
+    # Negation of Dual Numbers - named
+    ndd = -nda
+    @test ndd isa UnitDual
+    @test length(partials(ndd)) == 3
+    @test value(ndd) == -a
+    @test partials(ndd) === UnitPartials(a = -partials(nda).a, 
+                    b = -partials(nda).b, c = -partials(nda).c)
+
+
+    # Multiplication of Dual Numbers - unnamed
     dd = da*db
     @test dd isa UnitDual
     @test length(partials(dd)) == 3
@@ -79,7 +131,25 @@ using Suppressor
     @test value(ddu) == 3.0
     @test partials(ddu) === UnitPartials(3.0)
 
-    # Division of Dual Numbers
+
+    # Multiplication of Dual Numbers - named
+    ndd = nda*ndb
+    @test ndd isa UnitDual
+    @test length(partials(ndd)) == 3
+    @test value(ndd) == a*b
+    @test partials(ndd) === UnitPartials(a = b, b = a, c = zero(a*b/c))
+    nddr = nda*3
+    nddl = 3*nda
+    @test nddr === nddl
+    @test nddr isa UnitDual
+    @test value(nddr) == 3*a
+    @test partials(nddr) == UnitPartials(a = 3*partials(nda).a, 
+    b = 3*partials(nda).b, c = 3*partials(nda).c)
+    nddu = ndu*3
+    @test value(nddu) == 3.0
+    @test partials(nddu) === UnitPartials(u = 3.0)
+
+    # Division of Dual Numbers - unnamed
     dd = da/db
     @test dd isa UnitDual
     @test length(partials(dd)) == 3
@@ -101,13 +171,39 @@ using Suppressor
     @test partials(ddul) === UnitPartials(-3.0)
     @test inv(db) === 1/db
 
-    # Power
+    # Division of Dual Numbers - named
+    ndd = nda/ndb
+    @test ndd isa UnitDual
+    @test length(partials(ndd)) == 3
+    @test value(ndd) == a/b
+    @test partials(ndd) === UnitPartials(a = 1/b, b = -a/b^2, c = zero(1/c))
+    nddr = nda/2
+    nddl = 2/da
+    @test typeof(nddr) != typeof(nddl)
+    nddur = ndu/3
+    nddul = 3/ndu
+    @test typeof(nddur) == typeof(nddul)
+    @test value(nddur) == 1/3
+    @test value(nddul) == 3.0
+    @test partials(nddur) === UnitPartials(u = 1/3)
+    @test partials(nddul) === UnitPartials(u = -3.0)
+    @test inv(ndb) === 1/ndb
+
+    # Power - unnamed
     dd = db^2
     @test dd isa UnitDual
     @test value(dd) === b^2
     @test partials(dd) === UnitPartials((2*b*t for t in partials(db))...)
 
-    # Logical operators
+    # Power - named
+    ndd = ndb^2
+    @test ndd isa UnitDual
+    @test value(ndd) === b^2
+    @test partials(ndd) === UnitPartials(a = 2*b*partials(ndb).a, 
+                    b = 2*b*partials(ndb).b, c = 2*b*partials(ndb).c)
+
+
+    # Logical operators - unnamed
     @test da >= db
     @test da >= b
     @test_throws Unitful.DimensionError da >= b.val
@@ -126,7 +222,28 @@ using Suppressor
     @test du ≈ 1.0 + eps(Float64)
     @test 1.0 + eps(Float64) ≈ du
 
-    # Unary mathematical functions (most of them only works with unitless variables)
+
+    # Logical operators - named
+    @test nda >= ndb
+    @test nda >= b
+    @test_throws Unitful.DimensionError nda >= b.val
+    @test ndb <= nda
+    @test b <= nda
+    @test_throws Unitful.DimensionError b.val <= nda
+    @test nda == 2*ndb
+    @test nda == 2*b
+    @test nda ≈ UnitDual(a*(1.0 +  + eps(Float64)), a = 1.0, b = 0.0, c = zero(a/c))
+    @test nda != 2*b.val
+    @test ndu >= 0.5
+    @test ndu <= 1.5
+    @test 0.5 <= ndu
+    @test ndu == 1.0
+    @test 1.0 == ndu
+    @test ndu ≈ 1.0 + eps(Float64)
+    @test 1.0 + eps(Float64) ≈ ndu
+
+
+    # Unary mathematical functions (most of them only works with unitless variables) - unnamed
     @test sqrt(db) ≈ db^(1//2)
     @test cbrt(db) ≈ db^(1//3)
     @test abs(-db) === db
@@ -162,21 +279,76 @@ using Suppressor
     @test_throws MethodError acot(db)
     @test acot(du) == acot(1.0)
 
-    # Printing
+    # Unary mathematical functions (most of them only works with unitless variables) - named
+    @test sqrt(ndb) ≈ ndb^(1//2)
+    @test cbrt(ndb) ≈ ndb^(1//3)
+    @test abs(-ndb) === ndb
+    @test abs2(-ndb) === ndb^2
+    @test_throws MethodError log(ndb)
+    @test log(ndu) == log(1.0)
+    @test_throws MethodError log10(ndb)
+    @test log10(ndu) == log10(1.0)
+    @test_throws MethodError log2(ndb)
+    @test log2(ndu) == log2(1.0)
+    @test_throws MethodError exp(ndb)
+    @test exp(ndu) == exp(1.0)
+    @test_throws MethodError sin(ndb)
+    @test sin(ndu) == sin(1.0)
+    @test_throws MethodError cos(ndb)
+    @test cos(ndu) == cos(1.0)
+    @test_throws MethodError tan(ndb)
+    @test tan(ndu) == tan(1.0)
+    @test_throws MethodError sec(ndb)
+    @test sec(ndu) == sec(1.0)
+    @test_throws MethodError csc(ndb)
+    @test csc(ndu) == csc(1.0)
+    @test_throws MethodError cot(ndb)
+    @test cot(ndu) == cot(1.0)
+    @test_throws MethodError acos(ndb)
+    @test acos(ndu) == acos(1.0)
+    @test_throws MethodError atan(ndb)
+    @test atan(ndu) == atan(1.0)
+    @test_throws MethodError asec(ndb)
+    @test asec(ndu) == asec(1.0)
+    @test_throws MethodError acsc(ndb)
+    @test acsc(ndu) == acsc(1.0)
+    @test_throws MethodError acot(ndb)
+    @test acot(ndu) == acot(1.0)
+
+    # Printing - unnamed
     printdual = @capture_out print(da)
     @test '{' in printdual
     @test occursin("mol" , printdual)
+
+    # Printing - named
+    printdual = @capture_out print(nda)
+    @test '{' in printdual
+    @test '=' in printdual
+    @test occursin("mol" , printdual)
     
-    # Convenience functions
+    # Convenience functions  - unnamed
     da0 = zero(da)
     @test da0 isa UnitDual
     @test value(da0) === zero(a)
     @test partials(da0) === UnitPartials((zero(p) for p in partials(da))...)
-    @test zeros(da, 2) == [da0, da0]
+    @test zeros(typeof(da), 2) == [da0, da0]
     @test zeros(typeof(da), 2)  == [da0, da0]
 
-    # Iteration
+    # Convenience functions  - named
+    nda0 = zero(nda)
+    @test nda0 isa UnitDual
+    @test value(nda0) === zero(a)
+    # The following tests have some issues with conversion of FreeUnits into Float64
+    @test_broken partials(nda0) == UnitPartials(a = zero(a/a), b = zero(a/b), c = zero(a/c))
+    @test_broken zeros(typeof(nda), 2) == [nda0, nda0]
+    @test_broken zeros(typeof(nda), 2)  == [nda0, nda0]
+
+    # Iteration- unnamed
     @test length(da) === 1
     @test da.*[1,2] == [da, 2*da]
+
+    # Iteration- named
+    @test length(nda) === 1
+    @test nda.*[1,2] == [nda, 2*nda]
 
 end


### PR DESCRIPTION
Propagation of partial derivatives when the partials are named tuples is based on labels rather than positions (so the order in which they are stored may differ).